### PR TITLE
Show count in Results, Files and Logs tab, display message if no result is found and add highlight the critical files with an icon.

### DIFF
--- a/.coafile
+++ b/.coafile
@@ -17,7 +17,7 @@ use_spaces = true
 files = coalahtml/_coalahtml/index.html, coalahtml/_coalahtml/app/views/*.html
 bears = LineLengthBear, SpaceConsistencyBear
 use_spaces = true
-max_line_length = 90
+max_line_length = 100
 
 [python]
 # Patches may conflict with autopep8 so putting them in own section so they

--- a/.coafile
+++ b/.coafile
@@ -10,7 +10,7 @@ max_line_length = 90
 
 [css]
 files = coalahtml/_coalahtml/app/styles/*.css
-bears = LineLengthBear, SpaceConsistencyBear, CSSLintBear
+bears = LineLengthBear, SpaceConsistencyBear
 use_spaces = true
 
 [html]

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ node_modules
 Goopfile.lock
 npm-debug.log
 bower_components
+coalahtml/_coalahtml/data/*

--- a/coalahtml/_coalahtml/app/app.js
+++ b/coalahtml/_coalahtml/app/app.js
@@ -13,6 +13,7 @@ angular
       $http.get($rootScope.CONSTANTS.data + $rootScope.CONSTANTS.file_data)
         .then(function(file_data) {
           $rootScope.FILE_DATA = file_data.data;
+          $rootScope.filesCount = Object.keys(file_data.data).length;
       });
       $http.get($rootScope.CONSTANTS.data + $rootScope.CONSTANTS.files)
         .then(function(files) {

--- a/coalahtml/_coalahtml/app/app.js
+++ b/coalahtml/_coalahtml/app/app.js
@@ -2,14 +2,29 @@
 
 angular
   .module('coalaHtmlApp', ['ngRoute', 'ngSanitize'])
-  .run(function($rootScope) {
+  .run(['$rootScope', '$http', function($rootScope, $http) {
     $rootScope.LOG_LEVELS = ["DEBUG", "INFO", "WARNING", "ERROR"];
     $rootScope.RESULT_SEVERITY = ["INFO", "NORMAL", "MAJOR"];
     $rootScope.SEVERITY_TO_BOOTSTRAP = ["info", "warning", "danger"];
     $rootScope.LOG_LEVEL_TO_BOOTSTRAP = ["primary", "info", "warning",
                                          "danger"];
-  })
-  .config(function ($routeProvider) {
+    $http.get("data/Constants.json").then(function(constants) {
+      $rootScope.CONSTANTS = constants.data;
+      $http.get($rootScope.CONSTANTS.data + $rootScope.CONSTANTS.file_data)
+        .then(function(file_data) {
+          $rootScope.FILE_DATA = file_data.data;
+      });
+      $http.get($rootScope.CONSTANTS.data + $rootScope.CONSTANTS.files)
+        .then(function(files) {
+          $rootScope.FILES = files.data;
+      });
+      $http.get($rootScope.CONSTANTS.roothome)
+        .then(function(roothome) {
+          $rootScope.ROOTHOME = roothome.data;
+      });
+    });
+  }])
+  .config(['$routeProvider', function ($routeProvider) {
     $routeProvider
       .when('/', {
         templateUrl: 'app/views/main.html',
@@ -29,4 +44,4 @@ angular
       .otherwise({
         redirectTo: '/'
       });
-  });
+  }]);

--- a/coalahtml/_coalahtml/app/controllers/files.js
+++ b/coalahtml/_coalahtml/app/controllers/files.js
@@ -13,7 +13,7 @@ angular.module('coalaHtmlApp')
       $scope.fileBack = fileName.split("/").slice(0, -1).join('/');
       if ($rootScope.FILES.hasOwnProperty(fileName)) {
         $scope.fileType = "dir";
-        $scope.fileContents = {};
+        $scope.fileContents = [];
         $rootScope.FILES[fileName].forEach(function(file){
           var fileType = $rootScope.FILES.hasOwnProperty(file) ? "dir": "file";
           $scope.fileContents.push({'name' : file, 'type' : fileType});

--- a/coalahtml/_coalahtml/app/controllers/files.js
+++ b/coalahtml/_coalahtml/app/controllers/files.js
@@ -1,51 +1,35 @@
 'use strict';
 
 angular.module('coalaHtmlApp')
-  .controller('FilesCtrl', function ($scope, $http, $routeParams) {
-    var parseCoalaProject = function(fileName, projectDir, filesJSON) {
+  .controller('FilesCtrl',['$scope', '$routeParams', '$rootScope',
+    function ($scope, $routeParams, $rootScope) {
+    var parseCoalaProject = function(fileName) {
       /* Expected file structure in filesJSON:
        * JSON object with keys as directory relative to the project
        * path and values are files inside directory relative to the
        * project.
        * For files in the project root, the key should be root.
        */
-      filesJSON = filesJSON || projectDir + $scope.Constants.files;
-      $scope.data = [];
       $scope.fileBack = fileName.split("/").slice(0, -1).join('/');
-      $http.get(filesJSON).success(function(fJSON) {
-        if (fJSON.hasOwnProperty(fileName)) {
-          $scope.fileType = "dir";
-          $scope.fileContents = {};
-          for(var i_file = 0;i_file < fJSON[fileName].length;i_file += 1) {
-            var dirFile = fJSON[fileName][i_file];
-            var dirFileType = fJSON.hasOwnProperty(dirFile) ? "dir": "file";
-            $scope.fileContents[dirFile] = dirFileType;
-          }
-        } else {
-            $scope.fileType = "file";
-            $http.get(projectDir + $scope.Constants.file_data)
-            .success(function(fileData) {
-              var result = "";
-              fileData[fileName].forEach(function(line){
-                result += line;
-              });
-              $scope.fileContents = result;
-            });
-        }
-        $scope.data = fJSON;
-      }).error(function(e){
-        console.log(e);
-      });
+      if ($rootScope.FILES.hasOwnProperty(fileName)) {
+        $scope.fileType = "dir";
+        $scope.fileContents = {};
+        $rootScope.FILES[fileName].forEach(function(file){
+          var fileType = $rootScope.FILES.hasOwnProperty(file) ? "dir": "file";
+          $scope.fileContents.push({'name' : file, 'type' : fileType});
+        });
+      } else {
+          $scope.fileType = "file";
+          var result = "";
+          $rootScope.FILE_DATA[fileName].forEach(function(line){
+            result += line;
+          });
+          $scope.fileContents = result;
+      }
     };
-    $http.get("data/Constants.json").success(function(constants) {
-      $scope.Constants = constants;
-      $http.get($scope.Constants.roothome).success(function(roothome) {
-        $scope.fileName = $routeParams.fileName || roothome;
-        $scope.roothome = roothome;
-        parseCoalaProject($scope.fileName, $scope.Constants.data);
-      });
-    });
+    $scope.fileName = $routeParams.fileName || $rootScope.ROOTHOME;
+    parseCoalaProject($scope.fileName);
     $scope.basename = function(path_name){
       return path_name.split('/').slice(-1)[0];
     };
-  });
+  }]);

--- a/coalahtml/_coalahtml/app/controllers/files.js
+++ b/coalahtml/_coalahtml/app/controllers/files.js
@@ -33,7 +33,25 @@ angular.module('coalaHtmlApp')
     };
     $scope.fileName = $routeParams.fileName || $rootScope.ROOTHOME;
     parseCoalaProject($scope.fileName);
-    $scope.basename = function(path_name){
+
+    $scope.basename = function(path_name) {
+      path_name = path_name || $rootScope.ROOTHOME;
       return path_name.split('/').slice(-1)[0];
+    };
+    $scope.getNameLink = function(fileName) {
+      var linkNameContainer = [], files = fileName.split('/');
+      var fileNameLen = files.length,
+          rootHomeLen = $rootScope.ROOTHOME.split('/').length;
+      var link = "#/file/" + $rootScope.ROOTHOME;
+
+      linkNameContainer.push({'name':'/','link':link});
+      for (var index = rootHomeLen; index < fileNameLen; index++) {
+        link = link + '/' + files[index];
+        linkNameContainer.push({
+          'name' : files[index] + (index < fileNameLen-1 ? '/' : ''),
+          'link' : link
+        });
+      }
+      return linkNameContainer;
     };
   }]);

--- a/coalahtml/_coalahtml/app/controllers/files.js
+++ b/coalahtml/_coalahtml/app/controllers/files.js
@@ -16,7 +16,11 @@ angular.module('coalaHtmlApp')
         $scope.fileContents = [];
         $rootScope.FILES[fileName].forEach(function(file){
           var fileType = $rootScope.FILES.hasOwnProperty(file) ? "dir": "file";
-          $scope.fileContents.push({'name' : file, 'type' : fileType});
+          var resultFound = $rootScope.resultFiles[file] ? true : false;
+          $scope.fileContents.push({'name': file,
+                                    'type': fileType,
+                                    'result':resultFound});
+          console.log(resultFound + " " + file);
         });
       } else {
           $scope.fileType = "file";

--- a/coalahtml/_coalahtml/app/controllers/logs.js
+++ b/coalahtml/_coalahtml/app/controllers/logs.js
@@ -1,16 +1,11 @@
 'use strict';
 
 angular.module('coalaHtmlApp')
-  .controller('LogsCtrl', function ($scope, $http) {
-    var parseCoalaProject = function(projectDir, coalaJSON) {
-      coalaJSON = coalaJSON || projectDir + $scope.Constants.coala;
-      $scope.data = [];
-      $http.get(coalaJSON).success(function(response){
-        $scope.data = response.logs;
-      });
+  .controller('LogsCtrl', ['$scope', '$rootScope',
+    function ($scope, $rootScope) {
+    var parseCoalaProject = function() {
+      $scope.data = $rootScope.COALA_JSON.logs;
     };
-    $http.get("data/Constants.json").success(function(content) {
-      $scope.Constants = content;
-      parseCoalaProject($scope.Constants.data);
-    });
-  });
+
+    parseCoalaProject();
+  }]);

--- a/coalahtml/_coalahtml/app/controllers/main.js
+++ b/coalahtml/_coalahtml/app/controllers/main.js
@@ -24,9 +24,13 @@ angular.module('coalaHtmlApp')
         $http.get($rootScope.CONSTANTS.data + $rootScope.CONSTANTS.coala)
           .then(function(coala_json) {
             $rootScope.COALA_JSON = coala_json.data;
+            $rootScope.logsCount = coala_json.data.logs.length;
+            var resultsCount = 0;
             for (var section in $rootScope.COALA_JSON.results) {
               $rootScope.COALA_JSON.results[section].forEach(parseResult);
+              resultsCount += $rootScope.COALA_JSON.results[section].length;
             }
+            $rootScope.resultsCount = resultsCount;
             $scope.data.push(knownFiles);
         });
       };

--- a/coalahtml/_coalahtml/app/controllers/main.js
+++ b/coalahtml/_coalahtml/app/controllers/main.js
@@ -1,41 +1,35 @@
 'use strict';
 
 angular.module('coalaHtmlApp')
-  .controller('MainCtrl', function ($scope, $http) {
-    var parseCoalaProject = function(projectDir, coalaJSON) {
-      $http.get(projectDir + $scope.Constants.file_data)
-        .success(function(file_data) {
-          $scope.file_dict = angular.copy(file_data);
-          coalaJSON = coalaJSON || projectDir + $scope.Constants.coala;
-          $scope.data = [];
-          $http.get(coalaJSON).success(function(coala_json) {
-            var knownFiles = {};
-            var parseResult = function(el) {
-                el.affected_code.forEach(function(sourceRange){
-                    if (!(sourceRange.file in knownFiles)){
-                        knownFiles[sourceRange.file] = [];
-                    }
-                    knownFiles[sourceRange.file].push({
-                      "start":    sourceRange.start.line,
-                      "end":      sourceRange.end.line,
-                      "diffs":    el.diffs,
-                      "message":  el.message,
-                      "origin":   el.origin,
-                      "severity": el.severity
-                    });
-                });
-            };
-            for (var section in coala_json.results) {
-              if (coala_json.results[section].length > 0) {
-                coala_json.results[section].forEach(parseResult);
-              }
+  .controller('MainCtrl',["$scope", "$rootScope", "$http",
+    function($scope, $rootScope, $http) {
+    var parseCoalaProject = function() {
+        $scope.data = [];
+        var knownFiles = {};
+        var parseResult = function(result) {
+          result.affected_code.forEach(function(sourceRange) {
+            if (!(sourceRange.file in knownFiles)) {
+              knownFiles[sourceRange.file] = [];
+            }
+            knownFiles[sourceRange.file].push({
+              "start":    sourceRange.start.line,
+              "end":      sourceRange.end.line,
+              "diffs":    result.diffs,
+              "message":  result.message,
+              "origin":   result.origin,
+              "severity": result.severity
+            });
+          });
+        };
+        $http.get($rootScope.CONSTANTS.data + $rootScope.CONSTANTS.coala)
+          .then(function(coala_json) {
+            $rootScope.COALA_JSON = coala_json.data;
+            for (var section in $rootScope.COALA_JSON.results) {
+              $rootScope.COALA_JSON.results[section].forEach(parseResult);
             }
             $scope.data.push(knownFiles);
-          });
         });
       };
-    $http.get("data/Constants.json").success(function(constants) {
-      $scope.Constants = constants;
-      parseCoalaProject($scope.Constants.data);
-    });
-  });
+
+    parseCoalaProject();
+  }]);

--- a/coalahtml/_coalahtml/app/controllers/main.js
+++ b/coalahtml/_coalahtml/app/controllers/main.js
@@ -32,6 +32,7 @@ angular.module('coalaHtmlApp')
             }
             $rootScope.resultsCount = resultsCount;
             $scope.data.push(knownFiles);
+            $rootScope.resultFiles = knownFiles;
         });
       };
 

--- a/coalahtml/_coalahtml/app/styles/files.css
+++ b/coalahtml/_coalahtml/app/styles/files.css
@@ -8,3 +8,7 @@
 .filename{
     color: blue;
 }
+.result-found{
+    float:right;
+    color: red;
+}

--- a/coalahtml/_coalahtml/app/styles/main.css
+++ b/coalahtml/_coalahtml/app/styles/main.css
@@ -13,6 +13,14 @@
 .search-wrap {
     text-align: center;
 }
+.search{
+    padding: 3px;
+    text-align: center;
+    position: fixed;
+    top: 0px;
+    right: 0px;
+    margin: 10px;
+}
 .result-badge, .file-badge, .log-badge {
     padding: 4px 5px;
     margin-left: 0.5em;
@@ -25,4 +33,31 @@
 }
 .log-badge {
     background-color: #888DC8;
+}
+.app-body{
+    margin-top: 100px;
+}
+/* Dark theme */
+body-dark{
+  background-color:rgba(66, 81, 76, 0.91);
+}
+.code-dark{
+    background-color: #E7E7E7;
+}
+.navbar-default-dark {
+  background-color: #484747;
+  border-color: transparent;
+}
+
+/* Light theme */
+body-light{
+  background-color:#BDE5A6;
+}
+.navbar-default-light {
+  background-color: rgba(168, 212, 142, 0.96);
+  border-color: transparent;
+}
+.code-light{
+  background-color: transparent;
+  border: 1px solid #112C02;
 }

--- a/coalahtml/_coalahtml/app/styles/main.css
+++ b/coalahtml/_coalahtml/app/styles/main.css
@@ -13,3 +13,16 @@
 .search-wrap {
     text-align: center;
 }
+.result-badge, .file-badge, .log-badge {
+    padding: 4px 5px;
+    margin-left: 0.5em;
+}
+.result-badge {
+    background-color: #CE6F40;
+}
+.file-badge {
+    background-color: #88C88D;
+}
+.log-badge {
+    background-color: #888DC8;
+}

--- a/coalahtml/_coalahtml/app/views/files.html
+++ b/coalahtml/_coalahtml/app/views/files.html
@@ -5,7 +5,7 @@
     </h3>
     <table class="table table-striped table-bordered table-condensed"
            table-row-links>
-      <tr class="file-previous" ng-if="fileName !== roothome">
+      <tr class="file-previous" ng-if="fileName !== ROOTHOME">
         <td>
           <a ng-href="#/file/{{ fileBack }}">
             <span class="glyphicon glyphicon-arrow-left"></span>
@@ -33,7 +33,7 @@
     </h3>
     <table class="table table-striped table-bordered table-condensed"
            table-row-links>
-      <tr class="file-previous" ng-if="fileName !== roothome">
+      <tr class="file-previous" ng-if="fileName !== ROOTHOME">
         <td>
           <a ng-href="#/file/{{ fileBack }}">
             <span class="glyphicon glyphicon-arrow-left"></span>

--- a/coalahtml/_coalahtml/app/views/files.html
+++ b/coalahtml/_coalahtml/app/views/files.html
@@ -1,9 +1,13 @@
 <div class="files">
   <div class="dir-contents" ng-if="fileType === 'dir'">
     <h3>
-    Contents of <span class="filename">{{ fileName }}</span>
+      Contents of
+      <span ng-repeat= "file in getNameLink(fileName)" class="filename">
+        <a href="{{file.link}}">
+        {{file.name}}</a>
+      </span>
     </h3>
-    <table class="table table-striped table-bordered table-condensed"
+    <table class="table table-bordered table-condensed"
            table-row-links>
       <tr class="file-previous" ng-if="fileName !== ROOTHOME">
         <td>
@@ -31,9 +35,12 @@
   <div class="file-contents" ng-if="fileType === 'file'">
     <h3>
       Contents of
-      <span class="filename">{{ fileName }}</span>
+      <span ng-repeat= "file in getNameLink(fileName)" class="filename">
+        <a href="{{file.link}}">
+        {{file.name}}</a>
+      </span>
     </h3>
-    <table class="table table-striped table-bordered table-condensed"
+    <table class="table table-bordered table-condensed"
            table-row-links>
       <tr class="file-previous" ng-if="fileName !== ROOTHOME">
         <td>

--- a/coalahtml/_coalahtml/app/views/files.html
+++ b/coalahtml/_coalahtml/app/views/files.html
@@ -13,14 +13,14 @@
           </a>
         </td>
       </tr>
-      <tr ng-repeat="(dirFile, dirFileType) in fileContents">
+      <tr ng-repeat="fileContent in fileContents | orderBy:'name' " >
         <td>
-          <a ng-href="#/file/{{ dirFile }}">
+          <a ng-href="#/file/{{ fileContent.name }}">
             <span class="glyphicon glyphicon-file"
-                  ng-if="dirFileType === 'file'"></span>
+                  ng-if="fileContent.type === 'file'"></span>
             <span class="glyphicon glyphicon-folder-open"
-                  ng-if="dirFileType === 'dir'"></span>
-            <span class="file-name">{{ basename(dirFile) }}</span>
+                  ng-if="fileContent.type === 'dir'"></span>
+            <span class="file-name">{{ basename(fileContent.name) }}</span>
           </a>
         </td>
       </tr>

--- a/coalahtml/_coalahtml/app/views/files.html
+++ b/coalahtml/_coalahtml/app/views/files.html
@@ -21,6 +21,8 @@
             <span class="glyphicon glyphicon-folder-open"
                   ng-if="fileContent.type === 'dir'"></span>
             <span class="file-name">{{ basename(fileContent.name) }}</span>
+            <span class="result-found" ng-if="fileContent.result">
+              <i class="glyphicon glyphicon-exclamation-sign" ></i></span>
           </a>
         </td>
       </tr>

--- a/coalahtml/_coalahtml/app/views/logs.html
+++ b/coalahtml/_coalahtml/app/views/logs.html
@@ -7,3 +7,6 @@
     <span class="log-message">{{ log_message.message }}</span>
   </div>
 </div>
+<div ng-hide="logsCount">
+  <h3>No logs found.</h2>
+</div>

--- a/coalahtml/_coalahtml/app/views/main.html
+++ b/coalahtml/_coalahtml/app/views/main.html
@@ -13,7 +13,7 @@
       <br/>
       <span class="message">{{ item.message }}</span>
       <pre
-        ng-bind-html="file_dict[file].slice(item.start-1, item.end).join('\n')"
+        ng-bind-html="FILE_DATA[file].slice(item.start-1, item.end).join('\n')"
         class="prettyprint linenums:{{ item.start }}"></pre>
     </div>
   </div>

--- a/coalahtml/_coalahtml/app/views/main.html
+++ b/coalahtml/_coalahtml/app/views/main.html
@@ -1,4 +1,4 @@
-<div class="search-wrap">
+<div class="search-wrap" ng-show="resultsCount">
   <input ng-model="q" type="text" placeholder="Search" class="search"/>
 </div>
 <div ng-repeat="info in data">
@@ -17,4 +17,7 @@
         class="prettyprint linenums:{{ item.start }}"></pre>
     </div>
   </div>
+</div>
+<div ng-hide="resultsCount">
+  <h3>Everything's fine. No errors found.</h2>
 </div>

--- a/coalahtml/_coalahtml/index.html
+++ b/coalahtml/_coalahtml/index.html
@@ -54,9 +54,27 @@
           <div class="collapse navbar-collapse" id="js-navbar-collapse">
 
             <ul bs-nav-active class="nav navbar-nav">
-              <li><a href="#/">Results</a></li>
-              <li><a href="#/file/">Files</a></li>
-              <li><a href="#/logs">Logs</a></li>
+              <li>
+                <a href="#/">Results
+                  <span ng-if="resultsCount" class = "result-badge badge">
+                    {{ resultsCount }}
+                  </span>
+                </a>
+              </li>
+              <li>
+                <a href="#/file/">Files
+                  <span ng-if="filesCount" class = "file-badge badge">
+                    {{ filesCount }}
+                  </span>
+                </a>
+              </li>
+              <li>
+                <a href="#/logs">Logs
+                  <span ng-if="logsCount" class = "log-badge badge">
+                    {{ logsCount }}
+                  </span>
+                </a>
+              </li>
             </ul>
           </div>
         </div>

--- a/coalahtml/_coalahtml/index.html
+++ b/coalahtml/_coalahtml/index.html
@@ -36,7 +36,7 @@
 
     <!-- Add your site or application content here -->
     <div class="header">
-      <div class="navbar navbar-default" role="navigation">
+      <div class="navbar navbar-default navbar-fixed-top" role="navigation">
         <div class="container">
           <div class="navbar-header">
 
@@ -82,7 +82,7 @@
     </div>
 
     <div class="container">
-    <div ng-view=""></div>
+    <div class="app-body" ng-view=""></div>
     </div>
 
     <script src="bower_components/angular/angular.js"></script>

--- a/tests/specs/directives/BsNavActiveDirectiveSpec.js
+++ b/tests/specs/directives/BsNavActiveDirectiveSpec.js
@@ -2,7 +2,7 @@
 
 describe('BsNavActive Directive', function() {
 
-  var element, scope, location;
+  var element, scope, location, $httpBackend;
   var codeHTML = '<ul bs-nav-active class="nav navbar-nav">' +
                  '  <li class="item1"><a href="#/item1">item1</a></li>' +
                  '  <li class="item2"><a href="#/item2">item2</a></li>' +
@@ -18,7 +18,25 @@ describe('BsNavActive Directive', function() {
     location = $location;
     element = $compile(codeHTML)(scope);
   }));
-
+  beforeEach(inject(function ($injector) {
+    $httpBackend = $injector.get('$httpBackend');
+    $httpBackend.whenGET('data/Constants.json').respond(200, {
+      "data":"data",
+      "roothome":"data/roothome",
+      "file_data":"/file_data.json",
+      "files":"/files.json",
+      "coala":"/coala.json"
+    });
+    $httpBackend.whenGET('data/roothome').respond(200, {});
+    $httpBackend.whenGET('data/file_data.json').respond(200, {});
+    $httpBackend.whenGET('data/files.json').respond(200, {});
+    $httpBackend.whenGET('data/coala.json').respond(200, {});
+  }));
+  afterEach(function() {
+    $httpBackend.flush();
+    $httpBackend.verifyNoOutstandingExpectation();
+    $httpBackend.verifyNoOutstandingRequest();
+  });
   it('activates item', function () {
     location.path('item1');
     scope.$digest();

--- a/tests/specs/directives/PrettyprintDirectiveSpec.js
+++ b/tests/specs/directives/PrettyprintDirectiveSpec.js
@@ -2,7 +2,7 @@
 
 describe('Prettyprint Directive', function() {
 
-  var element, scope;
+  var element, scope, $httpBackend;
   var codeHTML = '<pre ng-bind-html="undefined_variable"' +
                  '     class="prettyprint"></pre>';
   beforeEach(module('coalaHtmlApp'));
@@ -10,7 +10,25 @@ describe('Prettyprint Directive', function() {
     scope = $rootScope.$new();
     element = $compile(codeHTML)(scope);
   }));
-
+  beforeEach(inject(function ($injector) {
+    $httpBackend = $injector.get('$httpBackend');
+    $httpBackend.whenGET('data/Constants.json').respond(200, {
+      "data":"data",
+      "roothome":"data/roothome",
+      "file_data":"/file_data.json",
+      "files":"/files.json",
+      "coala":"/coala.json"
+    });
+    $httpBackend.whenGET('data/roothome').respond(200, {});
+    $httpBackend.whenGET('data/file_data.json').respond(200, {});
+    $httpBackend.whenGET('data/files.json').respond(200, {});
+    $httpBackend.whenGET('data/coala.json').respond(200, {});
+  }));
+  afterEach(function() {
+    $httpBackend.flush();
+    $httpBackend.verifyNoOutstandingExpectation();
+    $httpBackend.verifyNoOutstandingRequest();
+  });
   it('runs pretty print', function () {
     expect(element.find('span').length).to.equal(0);
     scope.$digest();

--- a/tests/specs/directives/TableRowLinksDirectiveSpec.js
+++ b/tests/specs/directives/TableRowLinksDirectiveSpec.js
@@ -2,7 +2,7 @@
 
 describe('TableRowLinks Directive', function() {
 
-  var element, scope, location;
+  var element, scope, location, $httpBackend;
   var codeHTML = '<table table-row-links>' +
                  '  <tr class="item1">' +
                  '    <td><a ng-click="item1Clicked = true" ' +
@@ -19,7 +19,25 @@ describe('TableRowLinks Directive', function() {
     location = $location;
     element = $compile(codeHTML)(scope);
   }));
-
+  beforeEach(inject(function ($injector) {
+    $httpBackend = $injector.get('$httpBackend');
+    $httpBackend.whenGET('data/Constants.json').respond(200, {
+      "data":"data",
+      "roothome":"data/roothome",
+      "file_data":"/file_data.json",
+      "files":"/files.json",
+      "coala":"/coala.json"
+    });
+    $httpBackend.whenGET('data/roothome').respond(200, {});
+    $httpBackend.whenGET('data/file_data.json').respond(200, {});
+    $httpBackend.whenGET('data/files.json').respond(200, {});
+    $httpBackend.whenGET('data/coala.json').respond(200, {});
+  }));
+  afterEach(function() {
+    $httpBackend.flush();
+    $httpBackend.verifyNoOutstandingExpectation();
+    $httpBackend.verifyNoOutstandingRequest();
+  });
   it('adds link to row', function () {
     scope.$digest();
     expect(angular.element(element[0].querySelector('.item1'))


### PR DESCRIPTION
Changes added:
 * Display count for various tabs.
 * Sort the file hierarchy - makes navigation easier.
 * Rather than showing a blank space, add a suitable message in case of no results/logs are found.
 * Display n suitable icon along with the file name for the files that produced results.
 * Enable user to skip multiple directories while navigating. Clicking on individual level will navigate to that level.
See the
[demo](https://cloud.githubusercontent.com/assets/7397433/15913930/cf8d2342-2dfa-11e6-85e1-968f042dd69a.gif)
